### PR TITLE
docs(district): fix typo

### DIFF
--- a/src/app/district/interfaces/opendatasoft-district.ts
+++ b/src/app/district/interfaces/opendatasoft-district.ts
@@ -1,7 +1,7 @@
 import { Geometry } from 'geojson';
 
 /**
- * The structure of a district oject returned by opendatasoft's `georef-germany-kreis` dataset.
+ * The structure of a district object returned by opendatasoft's `georef-germany-kreis` dataset.
  */
 export interface OpendatasoftDistrict {
   krs_code: string; // district code


### PR DESCRIPTION
Fixes typo in the district District interface.