### PR TITLE
fix(search-details): replace unknown with actual return type

### DIFF
--- a/src/app/search-details/clicked-district-details/values.pipe.ts
+++ b/src/app/search-details/clicked-district-details/values.pipe.ts
@@ -4,7 +4,9 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'values',
 })
 export class ValuesPipe implements PipeTransform {
-  transform(value: { offenceName: string; offencesCount: number }[]): unknown {
+  transform(
+    value: { offenceName: string; offencesCount: number }[],
+  ): { name: string; value: number }[] {
     return value.map<{ name: string; value: number }>(co => ({
       name: co.offenceName,
       value: co.offencesCount,


### PR DESCRIPTION
Replaces the `unknown` return type of the `transform` function with 
`value: { offenceName: string; offencesCount: number }[]`