### PR TITLE
fix(search-details): restructure map callback

### DIFF
--- a/src/app/search-details/clicked-district-details/values.pipe.ts
+++ b/src/app/search-details/clicked-district-details/values.pipe.ts
@@ -4,10 +4,14 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'values',
 })
 export class ValuesPipe implements PipeTransform {
-  transform(value: { offenceName: string; offencesCount: number }[]): unknown {
-    return value.map<{ name: string; value: number }>(co => ({
-      name: co.offenceName,
-      value: co.offencesCount,
-    }));
+  transform(
+    commonOffences: { offenceName: string; offencesCount: number }[],
+  ): { name: string; value: number }[] {
+    return commonOffences.map<{ name: string; value: number }>(
+      ({ offenceName: name, offencesCount: value }) => ({
+        name,
+        value,
+      }),
+    );
   }
 }


### PR DESCRIPTION
Destructs the commonOffences object to get a cleaner object construction in the callback of the map function.